### PR TITLE
Use AsyncLoad instead of ImmediateLoad

### DIFF
--- a/QuiteEnoughRecipes.cs
+++ b/QuiteEnoughRecipes.cs
@@ -1,12 +1,31 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent;
 using Terraria.ModLoader;
+using Terraria.UI;
 
 namespace QuiteEnoughRecipes;
 
 public class QuiteEnoughRecipes : Mod
 {
+    public static void DrawItemIcon(Item item, int context, SpriteBatch spriteBatch, Vector2 screenPositionForItemCenter, float scale, float sizeLimit, Color environmentColor)
+    {
+        LoadItemAsync(item.type);
+        ItemSlot.DrawItemIcon(item, context, spriteBatch, screenPositionForItemCenter, scale, sizeLimit, environmentColor);
+    }
+
+    public static void LoadItemAsync(int i)
+    {
+        if (TextureAssets.Item[i].State == AssetState.NotLoaded)
+        {
+            Main.Assets.Request<Texture2D>(TextureAssets.Item[i].Name, AssetRequestMode.AsyncLoad);
+        }
+    }
 }

--- a/UIItemPanel.cs
+++ b/UIItemPanel.cs
@@ -48,7 +48,7 @@ public class UIItemPanel : UIElement
 		var inventoryBack = TextureAssets.InventoryBack.Value;
 		sb.Draw(inventoryBack, pos, null, Color.White, 0, Vector2.Zero, _scale, 0, 0);
 
-		ItemSlot.DrawItemIcon(DisplayedItem, -1, sb, pos + inventoryBack.Size() * _scale / 2,
+		QuiteEnoughRecipes.DrawItemIcon(DisplayedItem, -1, sb, pos + inventoryBack.Size() * _scale / 2,
 			_scale, 32, Color.White);
 
 		// Draw trapped chest indicator.

--- a/UIOptionPanel.cs
+++ b/UIOptionPanel.cs
@@ -80,7 +80,7 @@ public class UIOptionPanel<T> : UIPanel
 		{
 			base.DrawSelf(sb);
 			var dims = GetDimensions();
-			ItemSlot.DrawItemIcon(_item, -1, sb, dims.Center(), dims.Width / 50, 32, Color.White);
+			QuiteEnoughRecipes.DrawItemIcon(_item, -1, sb, dims.Center(), dims.Width / 50, 32, Color.White);
 		}
 	}
 

--- a/UISystem.cs
+++ b/UISystem.cs
@@ -42,7 +42,7 @@ public class UISystem : ModSystem
 			 */
 			for (int i = 0; i < ItemLoader.ItemCount; ++i)
 			{
-				Main.instance.LoadItem(i);
+				QuiteEnoughRecipes.LoadItemAsync(i);
 			}
 		}
 	}


### PR DESCRIPTION
### What is the bug?
Vanilla uses `AssetRequestMode.ImmediateLoad` when it calls `Main.LoadItem` which blocks the main thread loading the item.
Also related: #35 
### How did you fix the bug?
Use `AssetRequestMode.AsyncLoad` instead to prevent freezes. This also reduces the load time when `ShouldPreloadItems` is enabled.
See this [guide](https://github.com/tModLoader/tModLoader/wiki/Assets) for more information about the asset system.
### Are there alternatives to your fix?
Alternatively custom drawing code could be used to have more control over performance. 
Also I put these methods in the main mod class, I don't know if that's the best place for them or not.