### PR TITLE
Reforging Tab

### DIFF
--- a/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
@@ -44,6 +44,7 @@ Tabs: {
 	ItemDrops: Item Loot
 	NPCDrops: NPC Loot
 	GlobalDrops: Global Loot
+	Reforging: Reforging
 }
 
 Filters: {

--- a/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
@@ -44,6 +44,7 @@ Tabs: {
 	ItemDrops: 宝藏袋
 	NPCDrops: 掉落
 	GlobalDrops: 全局掉落
+	// Reforging: Reforging
 }
 
 Filters: {

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -229,6 +229,32 @@ public static class RecipeHandlers
 		}
 	}
 
+	// Shows the given item's usage in the reforge menu
+	public class ReforgeUsageHandler : IRecipeHandler
+	{
+		public LocalizedText HoverName { get; }
+			= Language.GetText("Mods.QuiteEnoughRecipes.Tabs.Reforging");
+
+		public Item TabItem { get; } = new(ItemID.IronHammer);
+
+		public IEnumerable<UIElement> GetRecipeDisplays(Item item)
+		{
+			if (!item.CanHavePrefixes()) yield break;
+
+			// Include the item with no prefixes
+			yield return new UIReforgePanel(new(item.type));
+
+			for (int i = 0; i < PrefixLoader.PrefixCount; i++)
+			{
+				var reforgeCopy = new Item(item.type);
+				if (reforgeCopy.Prefix(i))
+				{
+					yield return new UIReforgePanel(reforgeCopy);
+				}
+			}
+		}
+	}
+
 	private static bool RecipeAcceptsItem(Recipe r, Item i)
 	{
 		return r.requiredItem.Any(x => x.type == i.type)

--- a/UIQERState.cs
+++ b/UIQERState.cs
@@ -280,6 +280,7 @@ public class UIQERState : UIState
 		AddUsageHandler(new RecipeHandlers.TileUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ShimmerUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ItemDropUsageHandler());
+		AddUsageHandler(new RecipeHandlers.ReforgeUsageHandler());
 
 		AddInternalFilter(ItemID.StoneBlock, "Tiles", ItemPredicates.IsTile);
 		AddInternalFilter(ItemID.Furnace, "CraftingStations", ItemPredicates.IsCraftingStation);

--- a/UIReforgePanel.cs
+++ b/UIReforgePanel.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Xna.Framework;
+using System.Text;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.GameContent.UI.Elements;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace QuiteEnoughRecipes;
+public class UIReforgePanel : UIAutoExtend
+{
+	public UIReforgePanel(Item prefixedItem)
+	{
+		Height.Pixels = 50;
+		Width.Percent = 1;
+
+		Append(new UIItemPanel(prefixedItem));
+
+		var costText = new UIText($"Cost: {GetValueText(GetReforgePrice(prefixedItem))}", 0.8f);
+		costText.Left.Pixels = 60;
+		costText.Top.Pixels = 3;
+		Append(costText);
+
+		var reforgeIcon = new UIImage(TextureAssets.Reforge[0]);
+		reforgeIcon.Left.Pixels = 60;
+		reforgeIcon.Top.Pixels = 20;
+		Append(reforgeIcon);
+
+		var prefixText = new UIText(Lang.prefix[prefixedItem.prefix]);
+		prefixText.Left.Pixels = 100;
+		prefixText.Top.Pixels = 25;
+		Append(prefixText);
+	}
+
+	/*
+	 * Calculates the reforge price based on a given item
+	 * Taken from Main.DrawInventory()
+	 * Note: NPC happiness and the discount calculations are omitted 
+	 * due to potential side effects
+	 */
+	private static long GetReforgePrice(Item item)
+	{
+		int price = item.value;
+		price *= item.stack; // Added by TML should always be 1 in this case
+
+		bool canApplyDiscount = false;
+		if (ItemLoader.ReforgePrice(item, ref price, ref canApplyDiscount))
+		{
+			price /= 3;
+		}
+		return price;
+	}
+
+	/*
+	 * Creates colored coin text based on a given value as seen when reforging  
+	 * Taken from Main.DrawInventory()
+	 */
+	private static string GetValueText(long value)
+	{
+		var text = new StringBuilder();
+		var coins = Utils.CoinsSplit(value);
+		var copper = coins[0];
+		var silver = coins[1];
+		var gold = coins[2];
+		var platinum = coins[3];
+
+		void AddCoinText(Color color, int amount, int langIndex) =>
+			text.Append($"[c/{color.Hex3()}:{amount} {Lang.inter[langIndex].Value}] ");
+
+		if (platinum > 0)
+			AddCoinText(Colors.AlphaDarken(Colors.CoinPlatinum), platinum, 15);
+
+		if (gold > 0)
+			AddCoinText(Colors.AlphaDarken(Colors.CoinGold), gold, 16);
+
+		if (silver > 0)
+			AddCoinText(Colors.AlphaDarken(Colors.CoinSilver), silver, 17);
+
+		if (copper > 0)
+			AddCoinText(Colors.AlphaDarken(Colors.CoinCopper), copper, 18);
+
+		return text.ToString();
+	}
+}


### PR DESCRIPTION
### What is the new feature?
Adds a Reforging tab which lists an item in all the possible prefixes that can apply to that item.
The current design contains the following information per entry:

- The item with the prefix, meaning you can hover over it to see the stats
- The cost to reforge the item if it had that particular prefix
- The name of the prefix
I also included a non-prefixed item variant since reforging a item with no prefix is a valid usage at the tinkerer.
![image](https://github.com/user-attachments/assets/fefa606f-e36c-4b87-8e43-a6072972bbde)

### Why should this be added?
One of the ways items are used in to be reforged, so it fits well as its own tab. Additionally knowing what prefixes can be added to an item is pretty useful.
### Notes
The cost calculation in this design omits the discount applied by wearing a `Discount Card` or similar item, as well as the NPC happiness factors. The former could probably be added without issue. The latter however could be persuaded, but has side effects since it expects you to be talking to an NPC.
### Are there alternative designs?
An alternative design might be to list all the items with their prefixes together similar to an npc shop, but include the probabilities of getting each particular reforge. The issue here is the probability calculation, since I was having trouble wrapping my head around it. Other than that the other information could just be added to the item tooltip.