### PR TITLE
Add missing item shimmer conversions

### DIFF
--- a/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
@@ -80,4 +80,7 @@ Sorts: {
 	Value: Sort by Value
 }
 
-Conditions.BannerDrop: Drops once for every {0} kills
+Conditions: {
+	BannerDrop: Drops once for every {0} kills
+	CoinLuck: Provides {0} Coin Luck
+}

--- a/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
@@ -80,4 +80,7 @@ Sorts: {
 	Value: 按价值排序
 }
 
-// Conditions.BannerDrop: Drops once for every {0} kills
+Conditions: {
+	// BannerDrop: Drops once for every {0} kills
+	// CoinLuck: Provides {0} Coin Luck
+}

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -118,6 +118,7 @@ public static class RecipeHandlers
 			if (coinLuck > 0)
 			{
 				yield return new UIRecipePanel(new(), [new(i.type)], conditions: [CoinLuckCondition(coinLuck)]);
+				yield break;
 			}
 
 			foreach (var recipe in ShimmerRecipes.GetAllRecipes())
@@ -125,6 +126,7 @@ public static class RecipeHandlers
 				if (recipe.RequiredItems.Any(item => item.type == i.type))
 				{
 					yield return new UIRecipePanel(recipe);
+					yield break;
 				}
 			}
 

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -86,6 +86,14 @@ public static class RecipeHandlers
 
 		public IEnumerable<UIElement> GetRecipeDisplays(Item i)
 		{
+			foreach (var recipe in ShimmerRecipes.GetAllRecipes())
+			{
+				if (recipe.CreateItem.type == i.type)
+				{
+					yield return new UIRecipePanel(recipe);
+				}
+			}
+
 			for (int id = 0; id < ItemID.Sets.ShimmerTransformToItem.Length; ++id)
 			{
 				if (ShimmerTransformResult(id) == i.type)
@@ -106,6 +114,14 @@ public static class RecipeHandlers
 
 		public IEnumerable<UIElement> GetRecipeDisplays(Item i)
 		{
+			foreach (var recipe in ShimmerRecipes.GetAllRecipes())
+			{
+				if (recipe.RequiredItems.Any(item => item.type == i.type))
+				{
+					yield return new UIRecipePanel(recipe);
+				}
+			}
+
 			int id = ShimmerTransformResult(i.type);
 			if (id == -1) { yield break; }
 			yield return new UIRecipePanel(new(id), new List<Item>{new(i.type)});
@@ -244,9 +260,42 @@ public static class RecipeHandlers
 	 */
 	private static int ShimmerTransformResult(int inputItem)
 	{
+		/*
+		 * For some reason this item is in ShimmerTransformToItem despite having a special condition
+		 * this is the easiest way to prevent it showing up twice
+		 */
+		if (inputItem == ItemID.LihzahrdBrickWall) { return -1; }
 		int id = ItemID.Sets.ShimmerCountsAsItem[inputItem];
 		if (id == -1) { id = inputItem; }
 		return ItemID.Sets.ShimmerTransformToItem[id];
+	}
+
+	private static class ShimmerRecipes
+	{
+		public static readonly FakeRecipe LihzardBrickWallUnsafe = new(new(ItemID.LihzahrdWallUnsafe), [new(ItemID.LihzahrdBrickWall)], Conditions: [Condition.DownedGolem]);
+
+		public static readonly FakeRecipe RodOfHarmony = new(new(ItemID.RodOfHarmony), [new(ItemID.RodofDiscord)], Conditions: [Condition.DownedMoonLord]);
+		public static readonly FakeRecipe Terraformer = new(new(ItemID.Clentaminator2), [new(ItemID.Clentaminator)], Conditions: [Condition.DownedMoonLord]);
+		public static readonly FakeRecipe BottomlessShimmerBucket = new(new(ItemID.BottomlessShimmerBucket), [new(ItemID.BottomlessBucket)], Conditions: [Condition.DownedMoonLord]);
+		public static readonly FakeRecipe BottomlessWaterBucket = new(new(ItemID.BottomlessBucket), [new(ItemID.BottomlessShimmerBucket)], Conditions: [Condition.DownedMoonLord]);
+
+		public static readonly FakeRecipe HeavenforgeBrick = new(new(ItemID.HeavenforgeBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseFull]);
+		public static readonly FakeRecipe LunarRustBrick = new(new(ItemID.LunarRustBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseWaningGibbous]);
+		public static readonly FakeRecipe AstraBrick = new(new(ItemID.AstraBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseThirdQuarter]);
+		public static readonly FakeRecipe DarkCelestialBrick = new(new(ItemID.DarkCelestialBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseWaningCrescent]);
+		public static readonly FakeRecipe MercuryBrick = new(new(ItemID.MercuryBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseNew]);
+		public static readonly FakeRecipe StarRoyaleBrick = new(new(ItemID.StarRoyaleBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseWaxingCrescent]);
+		public static readonly FakeRecipe CryocoreBrick = new(new(ItemID.CryocoreBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseFirstQuarter]);
+		public static readonly FakeRecipe CosmicEmberBrick = new(new(ItemID.CosmicEmberBrick), [new(ItemID.LunarBrick)], Conditions: [Condition.MoonPhaseWaxingGibbous]);
+
+		private static IEnumerable<FakeRecipe>? _allRecipes = null;
+		public static IEnumerable<FakeRecipe> GetAllRecipes()
+		{
+			_allRecipes ??= typeof(ShimmerRecipes).GetFields()
+				.Where(field => field.FieldType == typeof(FakeRecipe))
+				.Select(field => field.GetValue(null) as FakeRecipe);
+			return _allRecipes;
+		}
 	}
 
 	// Get items that can be dropped when using the item with ID `itemID`.

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -118,7 +118,6 @@ public static class RecipeHandlers
 			if (coinLuck > 0)
 			{
 				yield return new UIRecipePanel(new(), [new(i.type)], conditions: [CoinLuckCondition(coinLuck)]);
-				yield break;
 			}
 
 			foreach (var recipe in ShimmerRecipes.GetAllRecipes())
@@ -126,7 +125,6 @@ public static class RecipeHandlers
 				if (recipe.RequiredItems.Any(item => item.type == i.type))
 				{
 					yield return new UIRecipePanel(recipe);
-					yield break;
 				}
 			}
 

--- a/UIRecipePanel.cs
+++ b/UIRecipePanel.cs
@@ -78,6 +78,12 @@ public class UIRecipePanel : UIAutoExtend
 	{
 	}
 
+	public UIRecipePanel(FakeRecipe recipe) :
+	this(recipe.CreateItem, recipe.RequiredItems, recipe.AcceptedGroups, recipe.RequiredTiles,
+		recipe.Conditions)
+	{
+	}
+
 	private static string CraftingStationName(int tileID)
 	{
 		return tileID == -1
@@ -85,3 +91,7 @@ public class UIRecipePanel : UIAutoExtend
 			: Lang.GetMapObjectName(MapHelper.TileToLookup(tileID, Recipe.GetRequiredTileStyle(tileID)));
 	}
 }
+
+public record FakeRecipe(Item CreateItem, List<Item>? RequiredItems = null,
+		List<int>? AcceptedGroups = null, List<int>? RequiredTiles = null,
+		List<Condition>? Conditions = null);


### PR DESCRIPTION
### What was added?
There are a few shimmer conversions that are handled manually by Vanilla in `Item.GetShimmered()`, most of them being conditional. These were added as `FakeRecipes` and fit within a `UIRecipesPanel` in the same way normal `Recipes` do.
Coins were also added to the usages panel since they provide [Coin Luck](https://terraria.wiki.gg/wiki/Luck#Coins) when tossed into shimmer. This was handled by using the condition text to display how much coin luck a particular coin adds.
![image](https://github.com/user-attachments/assets/568e39bd-68ac-4e4c-9b83-191231e236bd)

![image](https://github.com/user-attachments/assets/3b8475ac-a4bc-4d49-895c-b349e273c564)


### Are there alternative designs?
I could see a desire to give coin luck its own custom UI component. Currently it shows a empty item in the createItem section which signifies that no items are produced when shimmering coins, and uses the conditional text to explain what actually happens. I initially tried to use a dummy item, just so that the item slot isn't blank, but I felt like that would be even more confusing since from a glance it would look like it was the shimmer result. I guess if dummy items are ever used they need to clearly convey their dummy status.

### Notes
NPC conversions were considered out of scope for this PR and probably wouldn't make sense until a bestiary tab is added anyway. The only ones that might be worth adding are [Sparkle Slime Balloon](https://terraria.wiki.gg/wiki/Sparkle_Slime_Balloon) and critter items since they are **items** that convert to NPCs.

Also for some reason the [Lihzahrd Brick Wall](https://terraria.wiki.gg/wiki/Lihzahrd_Brick_Wall) is included in the `ShimmerTransformToItem` despite never being used in that way due to conditional logic. My admittedly lame solution was to return -1 in `ShimmerTransformResult()` for that one exceptional case to prevent duplicate entries.