### PR TITLE
Tile/Wall drops/placements tabs

### DIFF
--- a/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
@@ -44,6 +44,8 @@ Tabs: {
 	ItemDrops: Item Loot
 	NPCDrops: NPC Loot
 	GlobalDrops: Global Loot
+	TileDrops: Tile Drops
+	CreatedTiles: Created Tiles
 }
 
 Filters: {

--- a/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
@@ -46,6 +46,8 @@ Tabs: {
 	GlobalDrops: Global Loot
 	TileDrops: Tile Drops
 	CreatedTiles: Created Tiles
+	WallDrops: Wall Drops
+	CreatedWalls: Created Walls
 }
 
 Filters: {

--- a/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
@@ -44,6 +44,8 @@ Tabs: {
 	ItemDrops: 宝藏袋
 	NPCDrops: 掉落
 	GlobalDrops: 全局掉落
+	// TileDrops: Tile Drops
+	// CreatedTiles: Created Tiles
 }
 
 Filters: {

--- a/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
@@ -46,6 +46,8 @@ Tabs: {
 	GlobalDrops: 全局掉落
 	// TileDrops: Tile Drops
 	// CreatedTiles: Created Tiles
+	// WallDrops: Wall Drops
+	// CreatedWalls: Created Walls
 }
 
 Filters: {

--- a/QuiteEnoughRecipes.cs
+++ b/QuiteEnoughRecipes.cs
@@ -29,4 +29,12 @@ public class QuiteEnoughRecipes : Mod
 			Main.Assets.Request<Texture2D>(TextureAssets.Item[i].Name, AssetRequestMode.AsyncLoad);
 		}
 	}
+
+	public static void LoadTileAsync(int tileId)
+	{
+		if (TextureAssets.Tile[tileId].State == AssetState.NotLoaded)
+		{
+			Main.Assets.Request<Texture2D>(TextureAssets.Tile[tileId].Name, AssetRequestMode.AsyncLoad);
+		}
+	}
 }

--- a/QuiteEnoughRecipes.cs
+++ b/QuiteEnoughRecipes.cs
@@ -37,4 +37,12 @@ public class QuiteEnoughRecipes : Mod
 			Main.Assets.Request<Texture2D>(TextureAssets.Tile[tileId].Name, AssetRequestMode.AsyncLoad);
 		}
 	}
+
+	public static void LoadWallAsync(int wallId)
+	{
+		if (TextureAssets.Wall[wallId].State == AssetState.NotLoaded)
+		{
+			Main.Assets.Request<Texture2D>(TextureAssets.Wall[wallId].Name, AssetRequestMode.AsyncLoad);
+		}
+	}
 }

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -235,7 +235,7 @@ public static class RecipeHandlers
 	public class TileDropsSourceHandler : IRecipeHandler
 	{
 		public LocalizedText HoverName { get; }
-			= Language.GetText("Mods.QuiteEnoughRecipes.Tabs.GlobalDrops");
+			= Language.GetText("Mods.QuiteEnoughRecipes.Tabs.TileDrops");
 
 		public Item TabItem { get; } = new(ItemID.StoneBlock);
 
@@ -253,6 +253,23 @@ public static class RecipeHandlers
 
 				var safeStyle = Math.Max(0, style);
 				yield return new UIDropsPanel(new UITilePanel(id, safeStyle), [new(i.type, 1, 1, 1)]);
+			}
+		}
+	}
+
+	// Shows the tiles placed by a given item 
+	public class CreateTileUsageHandler : IRecipeHandler
+	{
+		public LocalizedText HoverName { get; }
+			= Language.GetText("Mods.QuiteEnoughRecipes.Tabs.CreatedTiles");
+
+		public Item TabItem { get; } = new(ItemID.StoneBlock);
+
+		public IEnumerable<UIElement> GetRecipeDisplays(Item i)
+		{
+			if (i.createTile != -1)
+			{
+				yield return new UIDropsPanel(new UITilePanel(i.createTile, i.placeStyle), [new(i.type, 1, 1, 1)]);
 			}
 		}
 	}

--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -385,11 +385,6 @@ public static class RecipeHandlers
 		_itemTypeToTileTypeAndTileStyle ??= TileTypeAndTileStyleToItemType.GroupBy(entry => entry.Value)
 			.ToDictionary(entry => entry.Key, entry => entry.Select(entry => entry.Key).ToList());
 
-	private static Dictionary<int, List<(int Style, int Item)>>? _tileTypeToTileStyleAndItemType = null;
-	internal static Dictionary<int, List<(int Style, int Item)>> TileTypeToTileStyleAndItemType =>
-		_tileTypeToTileStyleAndItemType ??= TileTypeAndTileStyleToItemType.GroupBy(entry => entry.Key.TileId)
-			.ToDictionary(entry => entry.Key, entry => entry.Select(entry => (entry.Key.Style, entry.Value)).ToList());
-
 	private static List<(int TileId, int Style)> GetTilesThatDropItem(int itemId)
 	{
 		if (ItemTypeToTileTypeAndTileStyle.TryGetValue(itemId, out var tile))

--- a/UIQERState.cs
+++ b/UIQERState.cs
@@ -276,12 +276,14 @@ public class UIQERState : UIState
 		AddSourceHandler(new RecipeHandlers.NPCDropSourceHandler());
 		AddSourceHandler(new RecipeHandlers.GlobalLootSourceHandler());
 		AddSourceHandler(new RecipeHandlers.TileDropsSourceHandler());
+		AddSourceHandler(new RecipeHandlers.WallDropsSourceHandler());
 
 		AddUsageHandler(new RecipeHandlers.BasicUsageHandler());
 		AddUsageHandler(new RecipeHandlers.TileUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ShimmerUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ItemDropUsageHandler());
 		AddUsageHandler(new RecipeHandlers.CreateTileUsageHandler());
+		AddUsageHandler(new RecipeHandlers.CreateWallUsageHandler());
 
 		AddInternalFilter(ItemID.StoneBlock, "Tiles", ItemPredicates.IsTile);
 		AddInternalFilter(ItemID.Furnace, "CraftingStations", ItemPredicates.IsCraftingStation);

--- a/UIQERState.cs
+++ b/UIQERState.cs
@@ -281,6 +281,7 @@ public class UIQERState : UIState
 		AddUsageHandler(new RecipeHandlers.TileUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ShimmerUsageHandler());
 		AddUsageHandler(new RecipeHandlers.ItemDropUsageHandler());
+		AddUsageHandler(new RecipeHandlers.CreateTileUsageHandler());
 
 		AddInternalFilter(ItemID.StoneBlock, "Tiles", ItemPredicates.IsTile);
 		AddInternalFilter(ItemID.Furnace, "CraftingStations", ItemPredicates.IsCraftingStation);

--- a/UIQERState.cs
+++ b/UIQERState.cs
@@ -275,6 +275,7 @@ public class UIQERState : UIState
 		AddSourceHandler(new RecipeHandlers.ItemDropSourceHandler());
 		AddSourceHandler(new RecipeHandlers.NPCDropSourceHandler());
 		AddSourceHandler(new RecipeHandlers.GlobalLootSourceHandler());
+		AddSourceHandler(new RecipeHandlers.TileDropsSourceHandler());
 
 		AddUsageHandler(new RecipeHandlers.BasicUsageHandler());
 		AddUsageHandler(new RecipeHandlers.TileUsageHandler());

--- a/UITilePanel.cs
+++ b/UITilePanel.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.ObjectData;
+using Terraria.UI;
+
+namespace QuiteEnoughRecipes;
+public class UITilePanel : UIElement
+{
+	public int TileId;
+	public int TileStyle;
+
+	public UITilePanel(int tileId, int style)
+	{
+		TileId = tileId;
+		TileStyle = style;
+
+		Width.Pixels = 50;
+		Height.Pixels = 50;
+	}
+
+	protected override void DrawSelf(SpriteBatch spriteBatch)
+	{
+		base.DrawSelf(spriteBatch);
+		DrawTile(spriteBatch);
+	}
+
+	private void DrawTile(SpriteBatch spriteBatch)
+	{
+		QuiteEnoughRecipes.LoadTileAsync(TileId);
+
+		if (Main.tileFrameImportant[TileId])
+		{
+			var tileData = TileObjectData.GetTileData(TileId, TileStyle);
+			if (tileData != null)
+			{
+				DrawMultiTile(spriteBatch, tileData);
+			}
+			else
+			{
+				DrawSingleTile(spriteBatch, new(0, 0));
+			}
+		}
+		else
+		{
+			DrawSingleTile(spriteBatch, new(9, 3));
+		}
+		
+	}
+
+	private void DrawSingleTile(SpriteBatch spriteBatch, Point tileOnSheet)
+	{
+		var texture = TextureAssets.Tile[TileId];
+		var dimensions = GetInnerDimensions();
+
+		// Fixes blurry textures
+		RasterizerState rasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
+		spriteBatch.End();
+		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, rasterizerState, null, Main.UIScaleMatrix);
+
+		var size = 16;
+		var padding = 2;
+		var x = tileOnSheet.X * (size + padding);
+		var y = tileOnSheet.Y * (size + padding);
+
+		spriteBatch.Draw(texture.Value, dimensions.Center(), new(x, y, size, size), Color.White, 0f, Vector2.One * (size / 2), 2, SpriteEffects.None, 0);
+	}
+
+	/*
+	 * Adapted from TileDefinitionOptionElement.DrawMultiTile(), but takes style information into account
+	 */
+	private void DrawMultiTile(SpriteBatch spriteBatch, TileObjectData tileData)
+	{
+		var dimensions = GetInnerDimensions();
+
+		// Fixes gaps in textures
+		RasterizerState rasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
+		spriteBatch.End();
+		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, rasterizerState, null, Main.UIScaleMatrix);
+
+		Vector2 positionTopLeft = dimensions.Position() + new Vector2(4, 4);
+		float drawDimensionHeight = dimensions.Height - 8;
+		float drawDimensionWidth = dimensions.Width - 8;
+		// changing to Max fixes gaps in crates and chests but breaks most other things, there is something fishy here
+		float drawScale = Math.Min(drawDimensionWidth / (tileData.CoordinateWidth * tileData.Width), drawDimensionHeight / tileData.CoordinateHeights.Sum());
+		float adjustX = tileData.Width < tileData.Height ? (tileData.Height - tileData.Width) / (tileData.Height * 2f) : 0f;
+		float adjustY = tileData.Height < tileData.Width ? (tileData.Width - tileData.Height) / (tileData.Width * 2f) : 0f;
+
+		Texture2D tileTexture = TextureAssets.Tile[TileId].Value;
+		int placeStyle = tileData.CalculatePlacementStyle(TileStyle, 0, 0);
+		int row = 0;
+		int drawYOffset = tileData.DrawYOffset;
+		int drawXOffset = tileData.DrawXOffset;
+		placeStyle += tileData.DrawStyleOffset;
+		int styleWrapLimit = tileData.StyleWrapLimit;
+		int styleLineSkip = tileData.StyleLineSkip;
+		if (tileData.StyleWrapLimitVisualOverride.HasValue)
+			styleWrapLimit = tileData.StyleWrapLimitVisualOverride.Value;
+
+		if (tileData.styleLineSkipVisualOverride.HasValue)
+			styleLineSkip = tileData.styleLineSkipVisualOverride.Value;
+
+		if (styleWrapLimit > 0)
+		{
+			row = placeStyle / styleWrapLimit * styleLineSkip;
+			placeStyle %= styleWrapLimit;
+		}
+
+		int topLeftX;
+		int topLeftY;
+		if (tileData.StyleHorizontal)
+		{
+			topLeftX = tileData.CoordinateFullWidth * placeStyle;
+			topLeftY = tileData.CoordinateFullHeight * row;
+		}
+		else
+		{
+			topLeftX = tileData.CoordinateFullWidth * row;
+			topLeftY = tileData.CoordinateFullHeight * placeStyle;
+		}
+
+		int tileWidth = tileData.Width;
+		int tileHeight = tileData.Height;
+		int maxTileDimension = Math.Max(tileData.Width, tileData.Height);
+
+		for (int i = 0; i < tileWidth; i++)
+		{
+			int x = topLeftX + i * (tileData.CoordinateWidth + tileData.CoordinatePadding);
+			int y = topLeftY;
+			for (int j = 0; j < tileHeight; j++)
+			{
+				if (j == 0 && tileData.DrawStepDown != 0)
+					drawYOffset += tileData.DrawStepDown;
+
+				if (TileId == 567)
+					drawYOffset = (j != 0) ? tileData.DrawYOffset : (tileData.DrawYOffset - 2);
+
+				int drawWidth = tileData.CoordinateWidth;
+				int drawHeight = tileData.CoordinateHeights[j];
+				if (TileId == 114 && j == 1)
+					drawHeight += 2;
+
+				spriteBatch.Draw(
+					sourceRectangle: new Rectangle(x, y, drawWidth, drawHeight),
+					texture: tileTexture,
+					position: new Vector2(
+						positionTopLeft.X + ((float)i / maxTileDimension + adjustX) * drawDimensionWidth,
+						positionTopLeft.Y + ((float)j / maxTileDimension + adjustY) * drawDimensionHeight
+					),
+					color: Color.White, rotation: 0f, origin: Vector2.Zero, scale: drawScale, effects: SpriteEffects.None, layerDepth: 0f);
+				y += drawHeight + tileData.CoordinatePadding;
+			}
+		}
+	}
+}

--- a/UITilePanel.cs
+++ b/UITilePanel.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria;
 using Terraria.GameContent;
+using Terraria.ID;
 using Terraria.ObjectData;
 using Terraria.UI;
 
@@ -15,11 +16,13 @@ public class UITilePanel : UIElement
 {
 	public int TileId;
 	public int TileStyle;
+	public string HoverText = "";
 
 	public UITilePanel(int tileId, int style)
 	{
 		TileId = tileId;
 		TileStyle = style;
+		HoverText = TileID.Search.GetName(tileId);
 
 		Width.Pixels = 50;
 		Height.Pixels = 50;
@@ -52,6 +55,10 @@ public class UITilePanel : UIElement
 			DrawSingleTile(spriteBatch, new(9, 3));
 		}
 		
+		if (IsMouseHovering)
+		{
+			Main.instance.MouseText(HoverText);
+		}
 	}
 
 	private void DrawSingleTile(SpriteBatch spriteBatch, Point tileOnSheet)

--- a/UIWallPanel.cs
+++ b/UIWallPanel.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+namespace QuiteEnoughRecipes;
+public class UIWallPanel : UIElement
+{
+	public int WallId { get; set; }
+
+	public int Border { get; set; }
+	public string HoverText { get; set; } = "";
+
+	public UIWallPanel(int wallId, int size = 50)
+	{
+		WallId = wallId;
+		HoverText = WallID.Search.GetName(wallId);
+		Border = 8;
+
+		Width.Pixels = size;
+		Height.Pixels = size;
+	}
+
+	protected override void DrawSelf(SpriteBatch spriteBatch)
+	{
+		base.DrawSelf(spriteBatch);
+		DrawWall(spriteBatch);
+	}
+
+	private void DrawWall(SpriteBatch spriteBatch)
+	{
+		QuiteEnoughRecipes.LoadWallAsync(WallId);
+
+		if (WallId > WallID.None && WallId < WallLoader.WallCount)
+		{
+			var startPos = new Point(324, 108);
+			DrawWall(spriteBatch, startPos);
+		}
+		
+		if (IsMouseHovering)
+		{
+			Main.instance.MouseText(HoverText);
+		}
+	}
+
+	private void DrawWall(SpriteBatch spriteBatch, Point startPos)
+	{
+		var texture = TextureAssets.Wall[WallId];
+		var dimensions = GetInnerDimensions();
+
+		// Fixes blurry textures
+		RasterizerState rasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
+		spriteBatch.End();
+		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, rasterizerState, null, Main.UIScaleMatrix);
+
+		var size = 32;
+		float drawScale = Math.Min((dimensions.Width - Border) / size, (dimensions.Height - Border) / size);
+
+		spriteBatch.Draw(texture.Value, dimensions.Center(), new(startPos.X, startPos.Y, size, size), Color.White, 0f, Vector2.One * (size / 2), drawScale, SpriteEffects.None, 0);
+	}
+}


### PR DESCRIPTION
### What is the new feature?
Adds 4 new tabs:
- Tile Drops - shows what tiles drop a given item
- Created Tiles - shows what tiles a given item places
- Wall Drops - shows what walls drop a given item
- Created Walls - shows what walls a given item places
![image](https://github.com/user-attachments/assets/d194a487-1e91-423c-9cea-93bc2d3e911c)
![image](https://github.com/user-attachments/assets/0e78d4a7-9f60-47ff-bb6f-abc08676a849)

### Why should this be added?
One very common source of items is to obtain them from breaking tiles/walls. Similarly the usage of many items is to place tiles/walls.

### Are there alternative designs?
Because of the similar nature of these tabs I could see combining Tile Drops/Wall Drops and Created Tiles/Created Walls into one tab. There just wasn't really an item or name that captured it well, so I separated the tabs for clarity.

Another thing to consider is wall/tile names. Walls/Tiles do not inherently have names like items do. Instead the name can be derived by the following methods: 
- The name of the item that places the tile **(doesn't always exist)**
- The name of the tile that drops from the tile **(could be more than one)**
- The name on the map **(often doesn't exist and ignores style)**
- The internal name **(could be anything and ignores styles)**

I went with the internal name for simplicity, but that can be adjusted.

### Notes
To draw tiles I used TML's implementation found in `TileDefinitionOptionElement.DrawMultiTile()`. There is some strange gapping issues when it comes to tiles with varying `TileObjectData.CoordinateHeights` (see Crates or Chests as an example). I "fixed" this by over scaling the image, basically inflating the image to fill the gaps, but it is a very lame solution.

There are a few limitations when it comes to getting the drops from tiles/walls. 
- `ModTile.GetItemDrops()` allows modders to provide additional item drops to tiles, but can't be used in this case since it expects tile coordinates.
- `ModTile.CanDrop()`, `ModWall.Drop()`, and `GlobalTile.CanDrop()` - allow for conditional drops which cannot be checked without coordinates.