### PR TITLE
Show recipe's mod in tooltips

### DIFF
--- a/IRecipe.cs
+++ b/IRecipe.cs
@@ -33,6 +33,7 @@ public class BasicRecipe : IRecipe
 	public List<int> AcceptedGroups = [];
 	public List<int> RequiredTiles = [];
 	public List<Condition> Conditions = [];
+	public Mod? SourceMod;
 
 	public BasicRecipe() {}
 
@@ -44,10 +45,11 @@ public class BasicRecipe : IRecipe
 		AcceptedGroups = recipe.acceptedGroups;
 		RequiredTiles = recipe.requiredTile;
 		Conditions = recipe.Conditions;
+		SourceMod = recipe.Mod;
 	}
 
 	public UIElement Element => new UIRecipePanel(Result, RequiredItems, AcceptedGroups,
-		RequiredTiles, Conditions);
+		RequiredTiles, Conditions, SourceMod);
 
 	public IEnumerable<IIngredient> GetIngredients()
 	{

--- a/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/en-US_Mods.QuiteEnoughRecipes.hjson
@@ -158,5 +158,9 @@ OptionGroups: {
 	}
 }
 
-Tooltips.DropChance: "{0} drop chance"
+Tooltips: {
+	DropChance: "{0} drop chance"
+	RecipeAddedBy: Recipe added by {0}
+}
+
 Conditions.BannerDrop: Drops once for every {0} kills

--- a/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
+++ b/Localization/zh-Hans_Mods.QuiteEnoughRecipes.hjson
@@ -158,5 +158,9 @@ OptionGroups: {
 	}
 }
 
-// Tooltips.DropChance: "{0} drop chance"
+Tooltips: {
+	// DropChance: "{0} drop chance"
+	// RecipeAddedBy: Recipe added by {0}
+}
+
 Conditions.BannerDrop: 每击杀{0}次掉落一个

--- a/UIRecipePanel.cs
+++ b/UIRecipePanel.cs
@@ -5,6 +5,8 @@ using Terraria.ID;
 using Terraria.Map;
 using Terraria.UI;
 using Terraria;
+using Terraria.ModLoader;
+using Terraria.Localization;
 
 namespace QuiteEnoughRecipes;
 
@@ -18,7 +20,7 @@ public class UIRecipePanel : UIAutoExtend
 	 */
 	public UIRecipePanel(Item createItem, List<Item>? requiredItems = null,
 		List<int>? acceptedGroups = null, List<int>? requiredTiles = null,
-		List<Condition>? conditions = null)
+		List<Condition>? conditions = null, Mod? sourceMod = null)
 	{
 		requiredItems ??= new();
 		acceptedGroups ??= new();
@@ -36,7 +38,7 @@ public class UIRecipePanel : UIAutoExtend
 			offset += width + 10;
 		};
 
-		appendElement(new UIItemPanel(createItem, 50), 50);
+		appendElement(new UIRecipeResultPanel(createItem, 50, sourceMod), 50);
 
 		var conditionStrings =
 			requiredTiles.Select(CraftingStationName)
@@ -75,7 +77,7 @@ public class UIRecipePanel : UIAutoExtend
 
 	public UIRecipePanel(Recipe recipe) :
 		this(recipe.createItem, recipe.requiredItem, recipe.acceptedGroups, recipe.requiredTile,
-			recipe.Conditions)
+			recipe.Conditions, recipe.Mod)
 	{
 	}
 
@@ -84,5 +86,29 @@ public class UIRecipePanel : UIAutoExtend
 		return tileID == -1
 			? "?"
 			: Lang.GetMapObjectName(MapHelper.TileToLookup(tileID, Recipe.GetRequiredTileStyle(tileID)));
+	}
+}
+
+public class UIRecipeResultPanel : UIItemPanel
+{
+	public Mod? AddByMod;
+
+	public UIRecipeResultPanel(Item? displayedItem, float width = 52, Mod? addByMod = null) : base(displayedItem, width)
+	{
+		AddByMod = addByMod;
+	}
+
+	public override void ModifyTooltips(Mod mod, List<TooltipLine> tooltips)
+	{
+		base.ModifyTooltips(mod, tooltips);
+
+		if (AddByMod is not null)
+		{
+			var line = Language.GetText("Mods.QuiteEnoughRecipes.Tooltips.RecipeAddedBy").Format(AddByMod.DisplayNameClean);
+			tooltips.Add(new TooltipLine(mod, "QER: recipe added", line)
+			{
+				OverrideColor = Main.OurFavoriteColor
+			});
+		}
 	}
 }


### PR DESCRIPTION
### What is the new feature?
Adds a line to the item tooltip to indicate what mod added the recipe for that item. 

![image](https://github.com/user-attachments/assets/361dc992-6ace-4a93-b276-3f1f613e177a)

### Why should this be added?
Knowing what recipes a mod adds is useful since mods add recipes for vanilla items.

### Are there alternative designs?
Currently it only works for `Recipes` since recipes are registered by Mod and thus know what mod added them.
It would be nice if this "mod source" could expand to more things, like what mod added an item to an NPC shop or what mod declared a shimmer transformation. But that would likely require hooking onto TML methods to track what content is added by other mods and is out of scope for now.