### PR TITLE
[Bug Fix] Check loaded state before using assets

### DIFF
--- a/QuiteEnoughRecipes.cs
+++ b/QuiteEnoughRecipes.cs
@@ -20,25 +20,26 @@ public class QuiteEnoughRecipes : Mod
 	public static void DrawItemIcon(Item item, int context, SpriteBatch spriteBatch,
 		Vector2 screenPositionForItemCenter, float scale, float sizeLimit, Color environmentColor)
 	{
-		LoadItemAsync(item.type);
-		ItemSlot.DrawItemIcon(item, context, spriteBatch, screenPositionForItemCenter, scale, sizeLimit, environmentColor);
-	}
-
-	public static void LoadItemAsync(int i)
-	{
-		if (TextureAssets.Item[i].State == AssetState.NotLoaded)
+		if (LoadItemAsync(item.type).IsLoaded)
 		{
-			Main.Assets.Request<Texture2D>(TextureAssets.Item[i].Name, AssetRequestMode.AsyncLoad);
+			ItemSlot.DrawItemIcon(item, context, spriteBatch, screenPositionForItemCenter, scale, sizeLimit, environmentColor);
 		}
 	}
 
-	public static void LoadNPCAsync(int i)
+	public static Asset<Texture2D> LoadTextureAsync(Asset<Texture2D> asset)
 	{
-		if (TextureAssets.Npc[i].State == AssetState.NotLoaded)
+		if (asset.State == AssetState.NotLoaded)
 		{
-			Main.Assets.Request<Texture2D>(TextureAssets.Npc[i].Name, AssetRequestMode.AsyncLoad);
+			return Main.Assets.Request<Texture2D>(asset.Name, AssetRequestMode.AsyncLoad);
 		}
+		return asset;
 	}
+
+	public static Asset<Texture2D> LoadItemAsync(int i) => 
+		LoadTextureAsync(TextureAssets.Item[i]);
+
+	public static Asset<Texture2D> LoadNPCAsync(int i) =>
+		LoadTextureAsync(TextureAssets.Npc[i]);
 
 	/*
 	 * When displaying the name of an ingredient that comes from a mod, this should be appended

--- a/UINPCPanel.cs
+++ b/UINPCPanel.cs
@@ -57,12 +57,17 @@ public class UINPCPanel : UIElement, IIngredientElement, IScrollableGridElement<
 				OwnerEntry = Entry,
 				UnlockState = BestiaryEntryUnlockState.CanShowPortraitOnly_1
 			};
-			Entry.Icon.Update(collectionInfo, rect,
-				new EntryIconDrawSettings(){
+
+			if (QuiteEnoughRecipes.LoadNPCAsync(NPCID).IsLoaded)
+			{
+				Entry.Icon.Update(collectionInfo, rect,
+				new EntryIconDrawSettings()
+				{
 					iconbox = rect,
 					IsHovered = _isHovering,
 					IsPortrait = false
 				});
+			}	
 		}
 
 		protected override void DrawSelf(SpriteBatch sb)
@@ -74,13 +79,16 @@ public class UINPCPanel : UIElement, IIngredientElement, IScrollableGridElement<
 				UnlockState = BestiaryEntryUnlockState.CanShowPortraitOnly_1
 			};
 
-			QuiteEnoughRecipes.LoadNPCAsync(NPCID);
-			Entry.Icon.Draw(collectionInfo, sb,
-				new EntryIconDrawSettings(){
+			if (QuiteEnoughRecipes.LoadNPCAsync(NPCID).IsLoaded)
+			{
+				Entry.Icon.Draw(collectionInfo, sb,
+				new EntryIconDrawSettings()
+				{
 					iconbox = GetDimensions().ToRectangle(),
 					IsHovered = _isHovering,
 					IsPortrait = false
 				});
+			}
 		}
 	}
 


### PR DESCRIPTION
### What is the bug?
NPCs would fail to load because their assets were not fully loaded. This would cause divide by zero errors in the logs.

https://github.com/user-attachments/assets/48588880-66ad-493b-8073-57e399d8ee99


[client.log](https://github.com/user-attachments/files/19413523/client.log)
### How did you fix the bug?
Check that assets are loaded before potentially using them. I did this for items too, just in case.
### Are there alternatives to your fix?
No

