### PR TITLE
Fix incorrect ingredient when using the shimmer panel

### DIFF
--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -96,7 +96,7 @@ public static class RecipeHandlers
 				if (id == -1) { yield break; }
 				yield return new BasicRecipe{
 					Result = new(id),
-					RequiredItems = [new(id)]
+					RequiredItems = [new(i.Item.type)]
 				};
 			}
 		}


### PR DESCRIPTION
### What is the bug?
When showing the usage of items in the shimmer panel it was showing the result twice.
### How did you fix the bug?
Set `RequiredItems` to the right value
### Are there alternatives to your fix?
No