### PR TITLE
[Performance] Improve item drop performance

### DIFF
--- a/RecipeHandlers.cs
+++ b/RecipeHandlers.cs
@@ -177,16 +177,13 @@ public static class RecipeHandlers
 
 			if (queryType == QueryType.Sources)
 			{
-				var item = new Item();
 				for (int itemID = 0; itemID < ItemLoader.ItemCount; ++itemID)
 				{
-					item.SetDefaults(itemID);
-
-					var droppedItems = GetItemDrops(item.type);
+					var droppedItems = GetItemDrops(itemID);
 					if (droppedItems.Any(info => info.itemId == i.Item.type))
 					{
 						yield return new ItemDropsRecipe{
-							Item = item.Clone(),
+							Item = new(itemID),
 							Drops = droppedItems
 						};
 					}


### PR DESCRIPTION
### What is the bug?
Item drops took many milliseconds more to compute and display on the browser compared to other Recipe Handlers.


### How did you fix the bug?
Removed the unnecessary item constructor call in favor of simply using the item type. It seems that the creation of a new item is actually an expensive operation. 

Before:
<img width="1080" height="217" alt="itemDropsTimes_preFix" src="https://github.com/user-attachments/assets/26c94586-1a4c-4fc3-9ece-50a1c7605038" />

After:
<img width="1331" height="215" alt="itemDropsTimes_postFix" src="https://github.com/user-attachments/assets/2d377470-146f-4c21-b1f0-ad3888c9ef5a" />

Benchmarks taken by adding a stopwatch to the following code in `UIQERState.cs`
```csharp
public bool ShowRecipes(IIngredient ingredient, QueryType queryType)
{
	Stopwatch timer = new();
	timer.Start();
	var recipes = Handler.GetRecipes(ingredient, queryType).ToList();
	timer.Stop();
	Main.NewText($"{Handler.GetType().Name} took {timer.ElapsedMilliseconds} ms");
	if (recipes.Count == 0) { return false; }
	SetRecipes(recipes);
	return true;
}
```

### Are there alternatives to your fix?
For best performance item drops and other queried results could be cached in a dictionary or something.